### PR TITLE
feat: Ubuntu/Debian support and minor fixes

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -90,6 +90,17 @@ fn detectLLVMPrefix() ?[]const u8 {
         return "/usr/local";
     } else |_| {}
 
+    // Linux - versioned LLVM paths (Ubuntu/Debian: /usr/lib/llvm-XX/)
+    {
+        const versions = [_][]const u8{ "20", "19", "18", "17", "16", "15", "14" };
+        for (versions) |ver| {
+            const path = std.fmt.allocPrint(std.heap.page_allocator, "/usr/lib/llvm-{s}/include/llvm-c/Core.h", .{ver}) catch continue;
+            if (std.fs.accessAbsolute(path, .{})) |_| {
+                return std.fmt.allocPrint(std.heap.page_allocator, "/usr/lib/llvm-{s}", .{ver}) catch continue;
+            } else |_| {}
+        }
+    }
+
     // Windows - check common LLVM installation paths
     if (builtin.os.tag == .windows) {
         const win_paths = [_][]const u8{

--- a/scripts/run-native-tests.sh
+++ b/scripts/run-native-tests.sh
@@ -41,6 +41,11 @@ requires_c_helper() {
     head -5 "$1" | grep -q "// Requires: c-helper"
 }
 
+# Extract -l flags from "// Requires: -lXXX" comments in first 5 lines
+get_link_flags() {
+    head -5 "$1" | grep -oP '// Requires: \K-l\S+' | tr '\n' ' '
+}
+
 # Check if test should be skipped (handled by different runner)
 should_skip() {
     head -5 "$1" | grep -q "// Skip: native-tests"
@@ -124,9 +129,12 @@ for f in $(find "$TEST_DIR" -name "*.kl" | sort); do
     fi
 
     # Normal test - compile and run
-    # Add linker flags for tests requiring C helper
+    # Add linker flags for tests requiring C helper or external libraries
+    LINK_FLAGS=$(get_link_flags "$f")
     if requires_c_helper "$f"; then
-        BUILD_CMD="$KLAR build $f -o $temp_bin -L/tmp -lklarhelper"
+        BUILD_CMD="$KLAR build $f -o $temp_bin -L/tmp -lklarhelper $LINK_FLAGS"
+    elif [ -n "$LINK_FLAGS" ]; then
+        BUILD_CMD="$KLAR build $f -o $temp_bin $LINK_FLAGS"
     else
         BUILD_CMD="$KLAR build $f -o $temp_bin"
     fi

--- a/selfhost/parser_expr.kl
+++ b/selfhost/parser_expr.kl
@@ -440,8 +440,7 @@ fn parse_identifier_or_struct(p: Parser) -> (Parser, string) {
         }
 
         // Bare Name#[T] without call or struct/enum literal — emit error but recover
-        let err_result: (Parser, string) = error_and_advance(p3, "expected '(' after type arguments in generic call")
-        p3 = err_result.0
+        p3 = error_and_advance(p3, "expected '(' after type arguments in generic call")
         let callee: string = "{\"kind\":\"identifier\",\"name\":" + json_str(name) + "}"
         return (p3, "{\"kind\":\"call\",\"callee\":" + callee + ",\"args\":[],\"type_args\":" + ta_json + "}")
     }
@@ -721,8 +720,7 @@ fn parse_generic_call(p: Parser, left: string) -> (Parser, string) {
     }
 
     // Type args without call — emit error but recover
-    let err_result: (Parser, string) = error_and_advance(p2, "expected '(' after type arguments in generic call")
-    p2 = err_result.0
+    p2 = error_and_advance(p2, "expected '(' after type arguments in generic call")
     let json: string = "{\"kind\":\"call\",\"callee\":" + left + ",\"args\":[],\"type_args\":" + ta_json + "}"
     return (p2, json)
 }

--- a/src/interpreter.zig
+++ b/src/interpreter.zig
@@ -258,6 +258,21 @@ pub const Interpreter = struct {
         if (self.global_env.get("parse_float")) |v| {
             if (v == .builtin) self.allocator.destroy(v.builtin);
         }
+        if (self.global_env.get("env_get")) |v| {
+            if (v == .builtin) self.allocator.destroy(v.builtin);
+        }
+        if (self.global_env.get("env_set")) |v| {
+            if (v == .builtin) self.allocator.destroy(v.builtin);
+        }
+        if (self.global_env.get("timestamp_now")) |v| {
+            if (v == .builtin) self.allocator.destroy(v.builtin);
+        }
+        if (self.global_env.get("fs_stat")) |v| {
+            if (v == .builtin) self.allocator.destroy(v.builtin);
+        }
+        if (self.global_env.get("process_run")) |v| {
+            if (v == .builtin) self.allocator.destroy(v.builtin);
+        }
         self.global_env.deinit();
         self.allocator.destroy(self.global_env);
     }

--- a/test/native/ffi/link_libm.kl
+++ b/test/native/ffi/link_libm.kl
@@ -1,5 +1,5 @@
 // Test linking with external library (-l flag)
-// This test requires linking with -lm (math library)
+// Requires: -lm
 //
 // Build: klar build test/native/ffi/link_libm.kl -lm
 // Expected output: 2


### PR DESCRIPTION
## Summary
- Add versioned LLVM path detection (llvm-14 through llvm-20) in `build.zig` for Ubuntu/Debian systems that install to `/usr/lib/llvm-XX/`
- Add generic `-l` flag extraction in native test runner via `// Requires: -lXXX` comment convention, enabling auto-linking of external libraries in tests
- Fix selfhost `parser_expr.kl` bug where `error_and_advance` return was incorrectly destructured as a tuple
- Add missing `deinit` cleanup for 5 interpreter builtins (`env_get`, `env_set`, `timestamp_now`, `fs_stat`, `process_run`)

## Test plan
- [x] Run `./run-build.sh` on Ubuntu with versioned LLVM install to verify detection
- [x] Run `./scripts/run-native-tests.sh` and confirm `link_libm` test passes via auto-linking
- [x] Run selfhost parser tests to confirm `error_and_advance` fix
- [x] Run `./run-tests.sh` for full regression check

🤖 Generated with [Claude Code](https://claude.com/claude-code)